### PR TITLE
Stop erasing `ErrorReply` stack

### DIFF
--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -63,12 +63,7 @@ export class ReconnectStrategyError extends Error {
   }
 }
 
-export class ErrorReply extends Error {
-  constructor(message: string) {
-    super(message);
-    this.stack = undefined;
-  }
-}
+export class ErrorReply extends Error {}
 
 export class SimpleError extends ErrorReply {}
 


### PR DESCRIPTION
### Description

`error.stack` being undefined makes debugging very difficult.
Given this restores standard JS Error behaviour, I have not added any tests.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?